### PR TITLE
Synchronize framework internal test list with pytest test list

### DIFF
--- a/splunk_add_on_ucc_modinput_test/functional/entities/executable.py
+++ b/splunk_add_on_ucc_modinput_test/functional/entities/executable.py
@@ -13,18 +13,20 @@ class ExecutableBase:
 
     @property
     def key(self):
-        if self._fn_bound_class:
-            fn_full_name = f"{self._fn_bound_class}::{self._fn_name}"
-        else:
-            fn_full_name = self._fn_name
-
-        return (self._fn_source_file, fn_full_name)
+        return (self._fn_source_file, self.fn_full_name)
 
     @property
     def original_name(self):
         if self._original_name == "__call__":
             return self._fn_bound_class.lower()
         return self._original_name
+
+    @property
+    def fn_full_name(self):
+        if self._fn_bound_class:
+            return f"{self._fn_bound_class}::{self._fn_name}"
+        else:
+            return self._fn_name
 
     def _inspect(self):
         if inspect.ismethod(self._function):

--- a/splunk_add_on_ucc_modinput_test/functional/entities/forge.py
+++ b/splunk_add_on_ucc_modinput_test/functional/entities/forge.py
@@ -152,6 +152,22 @@ class FrameworkForge(ExecutableBase):
         return self._scope
 
     @property
+    def tests_keys(self):
+        return list(self.tests)
+
+    @property
+    def name(self):
+        return self.key[1]
+
+    @property
+    def path(self):
+        return self.source_file
+
+    @property
+    def full_path(self):
+        return "::".join(self.key[:2])
+
+    @property
     def executions(self):
         return self._executions.list()
 

--- a/splunk_add_on_ucc_modinput_test/functional/entities/task.py
+++ b/splunk_add_on_ucc_modinput_test/functional/entities/task.py
@@ -74,7 +74,7 @@ class FrameworkTask:
 
     @property
     def forge_test_keys(self):
-        return list(self._forge.tests)
+        return list(self.tests_keys)
 
     @property
     def forge_name(self):
@@ -94,15 +94,15 @@ class FrameworkTask:
 
     @property
     def test_name(self):
-        return self.test_key[1]
+        return self._test.name
 
     @property
     def test_path(self):
-        return self.test_key[0]
+        return self._test.path
 
     @property
     def test_full_path(self):
-        return "::".join(self.test_key)
+        return self._test.full_path
 
     @property
     def probe_name(self):

--- a/splunk_add_on_ucc_modinput_test/functional/entities/test.py
+++ b/splunk_add_on_ucc_modinput_test/functional/entities/test.py
@@ -24,6 +24,18 @@ class FrameworkTest(ExecutableBase):
     def artifacts(self):
         return self._artifacts
 
+    @property
+    def name(self):
+        return self.key[1]
+
+    @property
+    def path(self):
+        return self.source_file
+
+    @property
+    def full_path(self):
+        return "::".join(self.key)
+
     def update_artifacts(self, artifacts):
         assert isinstance(artifacts, dict)
         return self._artifacts.update(artifacts)

--- a/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/__init__.py
+++ b/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/__init__.py
@@ -1,8 +1,10 @@
 from splunk_add_on_ucc_modinput_test.functional.pytest_plugin.hooks import (
+    pytest_deselected,
     pytest_collection_modifyitems,
     pytest_runtest_setup,
     pytest_runtest_call,
     pytest_runtest_teardown,
+    pytest_collection_finish,
 )
 from splunk_add_on_ucc_modinput_test.functional.pytest_plugin.options import (
     pytest_addoption,

--- a/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/utils.py
+++ b/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/utils.py
@@ -11,7 +11,7 @@ def _extract_parametrized_data(pyfuncitem):
     return pyfuncitem.keywords.node.name, callspec_params
 
 
-def _map_items_to_forged_tests(items):
+def _map_forged_tests_to_pytest_items(items):
     forged_tests = {}
     for item in items:
         test = dependency_manager.tests.lookup_by_function(item._obj)


### PR DESCRIPTION
Fix is required to
- ignore forged functions that are not test functions for pytest
- Execute forges properly when running tests for specific markers