### PR TITLE
fix: add error handling while tests collection

### DIFF
--- a/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/hooks.py
+++ b/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/hooks.py
@@ -31,6 +31,7 @@ from splunk_add_on_ucc_modinput_test.functional.pytest_plugin.utils import (
     _collect_parametrized_tests,
     _extract_parametrized_data,
     _map_forged_tests_to_pytest_items,
+    _check_session_terminal_output,
 )
 from pytest import Session, Config, Item
 from typing import Sequence
@@ -99,20 +100,7 @@ def pytest_collection_modifyitems(
 def pytest_collection_finish(session: Session) -> None:
     if dependency_manager.collectonly:
         return
-    # Access the terminal reporter to check for collection errors
-    terminal_reporter = session.config.pluginmanager.get_plugin(
-        "terminalreporter"
-    )
-    if terminal_reporter and "error" in terminal_reporter.stats:
-        errors = terminal_reporter.stats["error"]
-        if errors:
-            logger.error("Errors occurred during test collection:")
-            for error in errors:
-                logger.error(error.longrepr)
-            pytest.exit(
-                "Errors occurred during test collection. Exiting pytest.",
-                returncode=1,
-            )
+    _check_session_terminal_output(session)
 
     dependency_manager.start_bootstrap_execution()
 

--- a/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/utils.py
+++ b/splunk_add_on_ucc_modinput_test/functional/pytest_plugin/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import pytest
 from typing import Any, Dict, List, Tuple
 from splunk_add_on_ucc_modinput_test.functional import logger
 from splunk_add_on_ucc_modinput_test.functional.entities.test import (
@@ -21,7 +22,7 @@ from splunk_add_on_ucc_modinput_test.functional.entities.test import (
 from splunk_add_on_ucc_modinput_test.functional.manager import (
     dependency_manager,
 )
-from pytest import Item
+from pytest import Item, Session
 from _pytest.mark.structures import Mark
 
 from splunk_add_on_ucc_modinput_test.typing import ExecutableKeyType
@@ -142,3 +143,20 @@ def _log_test_order(items: List[Item]) -> None:
             logger.debug(f"NOT FOUND: {item}, {pytest_funcname} ")
 
     logger.info(order)
+
+
+def _check_session_terminal_output(session: Session) -> None:
+    # Access the terminal reporter to check for collection errors
+    terminal_reporter = session.config.pluginmanager.get_plugin(
+        "terminalreporter"
+    )
+    if terminal_reporter and "error" in terminal_reporter.stats:
+        errors = terminal_reporter.stats["error"]
+        if errors:
+            logger.error("Errors occurred during test collection:")
+            for error in errors:
+                logger.error(error.longrepr)
+            pytest.exit(
+                "Errors occurred during test collection. Exiting pytest.",
+                returncode=1,
+            )

--- a/tests/functional/flow/scenarios/invalid_parameters.py
+++ b/tests/functional/flow/scenarios/invalid_parameters.py
@@ -1,0 +1,50 @@
+import pytest
+from splunk_add_on_ucc_modinput_test.functional.decorators import (
+    bootstrap,
+    forge,
+)
+from typing import Dict
+import logging
+
+logger = logging.getLogger("ucc-modinput-test")
+
+
+def forge1(test_id: str, parametrized_param1: str) -> Dict[str, object]:
+    logger.info(
+        f"forge1 test_id={test_id}, parametrized_param1={parametrized_param1}"
+    )
+
+    return dict(forge1_parametrized_param1=parametrized_param1)
+
+
+def forge2(test_id: str, parametrized_param2: str) -> Dict[str, object]:
+    logger.info(
+        f"forge2 test_id={test_id}, parametrized_param2={parametrized_param2}"
+    )
+
+    return dict(forge2_parametrized_param2=parametrized_param2)
+
+
+@pytest.mark.parametrize(
+    "parametrized_param1,parametrized_param2",
+    [
+        ("param1-1"),
+        ("param-2", "param2-2"),
+    ],
+)
+@bootstrap(
+    forge(forge1),
+    forge(forge2),
+)
+def test_invalid_parametrized_parameters(
+    test_id: str,
+    parametrized_param1: str,
+    forge1_parametrized_param1: str,
+    parametrized_param2: str,
+    forge2_parametrized_param2: str,
+) -> None:
+    logger.info(
+        f"test_invalid_parametrized_parameters test_id={test_id} execution"
+    )
+    assert forge1_parametrized_param1 == parametrized_param1
+    assert forge2_parametrized_param2 == parametrized_param2

--- a/tests/functional/flow/test_arguments.py
+++ b/tests/functional/flow/test_arguments.py
@@ -59,6 +59,13 @@ def test_parametrized(pytester):
         )
 
 
+def test_wrongly_parametrized(pytester):
+    with ScenarioTester(pytester, "invalid_parameters") as tester:
+        tester.result.stdout.fnmatch_lines(
+            "*! _pytest.outcomes.Exit: Errors occurred during test collection. Exiting pytest. !*"  # noqa: E501
+        )
+
+
 def test_probes(pytester):
     with ScenarioTester(pytester, "probes") as tester:
         tester.result.assert_outcomes(passed=1)


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [X] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary
The process  freezes when test cases collection encounters an error. It unnecessary extends workflows to last for 6h (with no tests execution: 
https://splunk.atlassian.net/browse/ADDON-81078

### Changes

Check of the terminal messages was added. In case of error pytest.exit() method is called to exit the process.
Proper Test case in framework functional will also be added. 

### User experience

Please describe the user experience before and after this change. Screenshots are welcome for additional context.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [ ] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-test/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-test/contributing/#build-and-test)
* [ ] Changes are documented
* [ ] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-test/contributing/#pull-requests)
