### PR TITLE
fix: add service for cloud classic with no idm

### DIFF
--- a/splunk_add_on_ucc_modinput_test/common/splunk_instance.py
+++ b/splunk_add_on_ucc_modinput_test/common/splunk_instance.py
@@ -52,6 +52,7 @@ class Configuration:
         """
         Validate the index name according to Splunk's naming conventions.
         """
+        logger.info(f"Validate index name: {index_name}")
         if not index_name:
             reason = "Index name must not be empty"
             logger.error(reason)

--- a/splunk_add_on_ucc_modinput_test/functional/splunk/client.py
+++ b/splunk_add_on_ucc_modinput_test/functional/splunk/client.py
@@ -61,6 +61,10 @@ class SplunkClientBase:
         return self._splunk_configuration.service
 
     @property
+    def splunk_classic_no_idm_service(self) -> SplunkServicePool | None:
+        return self._splunk_configuration.classic_no_idm_service
+
+    @property
     def ta_api(
         self,
     ) -> swagger_client.api.default_api.DefaultApi:  # type: ignore    # noqa: E501, F821
@@ -153,6 +157,7 @@ class SplunkClientBase:
             acs_stack=self.config.acs_stack if self._is_cloud else None,
             acs_server=self.config.acs_server if self._is_cloud else None,
             splunk_token=self.config.token if self._is_cloud else None,
+            classic_no_idm_service=self.splunk_classic_no_idm_service,
         )
 
     def get_index(self, index_name: str) -> Index | None:


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [X] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary
While running tests on Splunk Cloud Classic, we use idm for running modiput tests. It turns out the getting indexes from url with idm is not an option. Hence there was a need to handle getting indexes from splunk url without idm prefix. 
More information can be found here: https://splunk.atlassian.net/browse/ADDON-81908 and https://splunk.slack.com/archives/C8RGU9196/p1750686803319729
### Changes

THis PR adds separate client for cloud classic instances (without idm) and fetches indexes from there instead of client with idm. 
### User experience

Please describe the user experience before and after this change. Screenshots are welcome for additional context.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [X] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-test/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-test/contributing/#build-and-test)
* [ ] Changes are documented
* [X] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-test/contributing/#pull-requests)
