### PR TITLE
refactor: change names of get_index and create_index methods in Confi…

### DIFF
--- a/splunk_add_on_ucc_modinput_test/common/splunk_instance.py
+++ b/splunk_add_on_ucc_modinput_test/common/splunk_instance.py
@@ -39,7 +39,7 @@ MODINPUT_TEST_SPLUNK_DEDICATED_INDEX = "MODINPUT_TEST_SPLUNK_DEDICATED_INDEX"
 
 class Configuration:
     @staticmethod
-    def get_index_from_classic_instance(
+    def _get_index_from_classic_instance(
         index_name: str,
         client_service: SplunkServicePool,
         acs_stack: str,
@@ -84,7 +84,7 @@ class Configuration:
             return None
 
     @staticmethod
-    def get_index(
+    def _get_index(
         index_name: str,
         client_service: SplunkServicePool,
         acs_stack: str | None = None,
@@ -98,7 +98,7 @@ class Configuration:
                 "splunkcloud.com" in client_service._host.lower()
                 and not client_service._host.startswith(acs_stack)
             ):
-                return Configuration.get_index_from_classic_instance(
+                return Configuration._get_index_from_classic_instance(
                     index_name,
                     client_service,
                     acs_stack,
@@ -227,7 +227,7 @@ class Configuration:
             pytest.exit(idx_not_created_msg)
 
     @staticmethod
-    def create_index(
+    def _create_index(
         index_name: str,
         client_service: SplunkServicePool,
         *,
@@ -236,7 +236,7 @@ class Configuration:
         acs_server: str | None = None,
         splunk_token: str | None = None,
     ) -> Index:
-        if Configuration.get_index(
+        if Configuration._get_index(
             index_name,
             client_service,
             acs_stack,
@@ -253,7 +253,7 @@ class Configuration:
                 acs_server=acs_server,
                 splunk_token=splunk_token,
             )
-            created_index = Configuration.get_index(
+            created_index = Configuration._get_index(
                 index_name,
                 client_service,
                 acs_stack,
@@ -361,7 +361,7 @@ class Configuration:
         )
 
         if dedicated_index_name:
-            instance._dedicated_index = cls.get_index(
+            instance._dedicated_index = cls._get_index(
                 dedicated_index_name, instance._service
             )
             if not instance._dedicated_index:
@@ -378,7 +378,7 @@ class Configuration:
                     test in splunk {instance._host}"
             )
         else:
-            instance._dedicated_index = instance.create_index(
+            instance._dedicated_index = instance._create_index(
                 f"idx_{utils.Common().sufix}",
                 instance._service,
                 is_cloud=instance._is_cloud,

--- a/splunk_add_on_ucc_modinput_test/functional/splunk/client.py
+++ b/splunk_add_on_ucc_modinput_test/functional/splunk/client.py
@@ -150,7 +150,7 @@ class SplunkClientBase:
         return "splunkcloud.com" in self.config.host.lower()
 
     def create_index(self, index_name: str) -> Index:
-        return self.config.create_index(
+        return self.config._create_index(
             index_name,
             self.splunk,
             is_cloud=self._is_cloud,
@@ -160,7 +160,7 @@ class SplunkClientBase:
         )
 
     def get_index(self, index_name: str) -> Index | None:
-        return self.config.get_index(
+        return self.config._get_index(
             index_name,
             self.splunk,
             acs_stack=self.config.acs_stack if self._is_cloud else None,

--- a/tests/unit/common/test_splunk_instance.py
+++ b/tests/unit/common/test_splunk_instance.py
@@ -44,7 +44,7 @@ def test_get_index_from_classic_instance_none(mock_urlopen, response_status):
     mock_client._port = 8089
     mock_client._username = "mock_user"
     mock_client._password = "mock_password"
-    cloud_index = Configuration.get_index_from_classic_instance(
+    cloud_index = Configuration._get_index_from_classic_instance(
         "test_index",
         mock_client,
         "mock_acs",


### PR DESCRIPTION

**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [X] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

Test runs: 

https://cd.splunkdev.com/taautomation/ta-automation-compatibility-tests/-/pipelines/28434776
https://github.com/splunk/splunk-add-on-for-salesforce/actions/runs/16725159760/job/47339430131

### Changes
This PR refactors Configuration class methods get_index -> _get_index, create_index -> _create_index. Developers should choose to create/create indexes by using SplunkClientBase class methods. 

Please provide a summary of the changes.

### User experience

Please describe the user experience before and after this change. Screenshots are welcome for additional context.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [ ] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-test/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-test/contributing/#build-and-test)
* [ ] Changes are documented
* [ ] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-test/contributing/#pull-requests)
