### PR TITLE
fix: update index creation

### DIFF
--- a/splunk_add_on_ucc_modinput_test/common/splunk_instance.py
+++ b/splunk_add_on_ucc_modinput_test/common/splunk_instance.py
@@ -145,7 +145,6 @@ class Configuration:
                 "maxDataSizeMB": 0,
                 "name": index_name,
                 "searchableDays": 365,
-                "splunkArchivalRetentionDays": 366,
                 "totalEventCount": "0",
                 "totalRawSizeMB": "0",
             }


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

DDAA/DDSS is not supported in azure environments, moreover splunkArchivalRetentionDays applies after searchableDays which is already 1 year, Hence removing splunkArchivalRetentionDays from index creation payload

### User experience

Test run:
Enterprise: https://github.com/splunk/splunk-add-on-for-salesforce/actions/runs/17118813093
Aws Cloud: https://cd.splunkdev.com/taautomation/ta-automation-compatibility-tests/-/pipelines/28980311/
Azure cloud: https://cd.splunkdev.com/taautomation/ta-automation-compatibility-tests/-/pipelines/28937590/

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [ ] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-test/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-test/contributing/#build-and-test)
* [ ] Changes are documented
* [ ] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-test/contributing/#pull-requests)
