### PR TITLE
fix: add check for failed tasks in attched forges

### DIFF
--- a/splunk_add_on_ucc_modinput_test/functional/entities/collections.py
+++ b/splunk_add_on_ucc_modinput_test/functional/entities/collections.py
@@ -173,3 +173,11 @@ class TaskCollection:
             else:
                 pending.append(task)
         return done, pending
+
+    def get_inplace_tasks_list(
+        self, test_key: ExecutableKeyType
+    ) -> List[FrameworkTask]:
+        inplace_tasks_list = [
+            task for _, _, task in self.enumerate_inplace_tasks(test_key)
+        ]
+        return inplace_tasks_list

--- a/splunk_add_on_ucc_modinput_test/functional/manager.py
+++ b/splunk_add_on_ucc_modinput_test/functional/manager.py
@@ -562,6 +562,8 @@ class TestDependencyManager(PytestConfigAdapter):
             exec_steps.append([tasks])
         logger.debug(dump)
         self.inplace_tasks_execution(exec_steps)
+        inplace_tasks_list = self.tasks.get_inplace_tasks_list(test.key)
+        self._check_failed_tasks(test, inplace_tasks_list)
 
     def test_setup_error_report(
         self, test: FrameworkTest


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [X] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary
This PR ensures consistent behaviour for performing forges using bootstrap and attached decorators. Previously errors in attached forges did not propagate to test (which in some cases allowed tests to pass), while any error in bootstrapped forges resulted with errored test. From now on, the behaviour will be the same for both decorators (error in forge will imply error in test). 

Related Jira: 
https://splunk.atlassian.net/browse/ADDON-82933
### Changes

Please provide a summary of the changes.

### User experience

Please describe the user experience before and after this change. Screenshots are welcome for additional context.

## Checklist
Tests done:
* [X]  https://github.com/splunk/splunk-add-on-for-google-workspace/actions/runs/17297975117/job/49102200754
* [X] https://github.com/splunk/splunk-add-on-for-microsoft-office-365/actions/runs/17298177430/job/49103738559

If an item doesn't apply to your changes, leave it unchecked.

* [ ] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-test/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-test/contributing/#build-and-test)
* [ ] Changes are documented
* [ ] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-test/contributing/#pull-requests)
