### PR TITLE
ci: migrate GH_TOKEN_ADMIN to GitHub App token in release workflow

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -271,6 +271,13 @@ jobs:
           # Very important: semantic-release won't trigger a tagged
           # build if this is not set false
           persist-credentials: false
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.7"
@@ -290,7 +297,7 @@ jobs:
           extra_plugins: |
             semantic-release-replace-plugin
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       - if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
         run: |
           poetry build


### PR DESCRIPTION
## Summary

- Replace the long-lived PAT (`GH_TOKEN_ADMIN`) with a short-lived GitHub App installation token in the `release` job of `build-test-release.yml`.
- Add an `actions/create-github-app-token@v3` step that generates a scoped token using `GH_APP_CLIENT_ID` and `GH_APP_PRIVATE_KEY` secrets (already synced to this repo).
- Reference the generated token via `steps.app-token.outputs.token` instead of `secrets.GH_TOKEN_ADMIN` for the semantic-release step.

Made with [Cursor](https://cursor.com)